### PR TITLE
Fixed element_text for Section Heading

### DIFF
--- a/fountain/fountain.py
+++ b/fountain/fountain.py
@@ -181,7 +181,7 @@ class Fountain:
                 self.elements.append(
                     FountainElement(
                         'Section Heading',
-                        full_strip[depth:],
+                        full_strip[depth:].strip(),
                         section_depth=depth,
                         original_line=linenum,
                         original_content=line


### PR DESCRIPTION
In Section Heading element, if spaces between '#' and the text would be removed, it's really helpful.